### PR TITLE
feat(auth): Implement password hashing and response DTO

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.14</version>
 		</dependency>
+		<dependency>
+    		<groupId>org.springframework.boot</groupId>
+    		<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/db/ecotrack/ecotrack_api/config/SecurityConfig.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/config/SecurityConfig.java
@@ -12,20 +12,29 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
+    private static final String[] PUBLIC_PATHS = {
+        "/api/users/**",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/swagger-resources/**",
+        "/webjars/**"
+    };
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http ) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
-                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers(PathRequest.toH2Console()).permitAll()
-                        .requestMatchers("/api/users/**").permitAll()
-                        .anyRequest().authenticated());
-        return http.build();
+            .csrf(csrf -> csrf.disable( ))
+            .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+            .authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(PathRequest.toH2Console()).permitAll()
+                .requestMatchers(PUBLIC_PATHS).permitAll()
+                .anyRequest().authenticated()
+            );
+        return http.build( );
     }
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/config/SecurityConfig.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package br.db.ecotrack.ecotrack_api.config;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(PathRequest.toH2Console()).permitAll()
+                        .requestMatchers("/api/users/**").permitAll()
+                        .anyRequest().authenticated());
+        return http.build();
+    }
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/UserController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/UserController.java
@@ -2,11 +2,9 @@ package br.db.ecotrack.ecotrack_api.controller;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import br.db.ecotrack.ecotrack_api.domain.entity.User;
 import br.db.ecotrack.ecotrack_api.domain.entity.dto.UserRequestDto;
+import br.db.ecotrack.ecotrack_api.domain.entity.dto.UserResponseDto;
 import br.db.ecotrack.ecotrack_api.service.UserService;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,9 +21,9 @@ public class UserController {
   }
 
   @PostMapping
-  public ResponseEntity<User> postMethodName(@RequestBody UserRequestDto userRequestDto) {
-    User createUser = userService.createUser(userRequestDto);
-    return ResponseEntity.status(HttpStatus.CREATED).body(createUser);
+  public ResponseEntity<UserResponseDto> postMethodName(@RequestBody UserRequestDto userRequestDto) {
+    UserResponseDto createdUserDto = userService.createUser(userRequestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(createdUserDto);
   }
 
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/User.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/User.java
@@ -32,7 +32,7 @@ public class User {
   private String email;
 
   @Pattern(regexp = ".{8,}", message = "Password must be at least 8 characters long")
-  @Column(nullable = false, length = 50)
+  @Column(nullable = false, length = 225)
   private String password;
 
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/dto/UserResponseDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/dto/UserResponseDto.java
@@ -1,0 +1,7 @@
+package br.db.ecotrack.ecotrack_api.domain.entity.dto;
+
+public record UserResponseDto(
+        Long id,
+        String name,
+        String email) {
+}


### PR DESCRIPTION
### Description

This PR implements security enhancements to the user registration flow, as detailed in issue #4. It addresses two main vulnerabilities:

1.  **Password Hashing:** Passwords are now securely hashed using **BCrypt** before being persisted to the database. This prevents plain-text password exposure in case of a database breach.
2.  **Secure API Response:** The user registration endpoint (`POST /api/users`) now returns a `UserResponseDto`, which omits the password field entirely. This prevents sensitive data leakage through the API contract.

Additionally, the Spring Security configuration was updated to allow public access to the registration endpoint and the H2 Console in the development environment.

---

### How to Test

To verify the changes, please follow these steps:

1.  **Run the application** and ensure it starts correctly.
2.  **Send a `POST` request** to `/api/users` with a new user payload (e.g., using Postman or Insomnia).
    ```json
    {
        "name": "Test User",
        "email": "test@example.com",
        "password": "password123"
    }
    ```
3.  **Verify the API Response:**
    - [ ] Confirm the HTTP status is `201 Created`.
    - [ ] Confirm the JSON response body **does not** contain the `password` field. It should look like this:
      ```json
      {
          "id": 1,
          "name": "Test User",
          "email": "test@example.com"
      }
      ```
4.  **Verify the Database:**
    - [ ] Access the H2 Console (at `/h2-console`).
    - [ ] Run the query `SELECT * FROM USERS;`.
    - [ ] Confirm the `password` column for the new user contains a long hash string (e.g., starting with `$2a$10$...`) and not `password123`.

---

### Related Issue
Ref: #4
