### PR TITLE
Feat/29/purchase crud dto mapper

### DIFF
--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
@@ -1,0 +1,72 @@
+package br.db.ecotrack.ecotrack_api.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
+import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
+import br.db.ecotrack.ecotrack_api.service.PurchaseService;
+import jakarta.validation.Valid;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/purchases")
+public class PurchaseController {
+
+    private final PurchaseService purchaseService;
+
+    public PurchaseController(PurchaseService purchaseService) {
+        this.purchaseService = purchaseService;
+    }
+
+    @PostMapping
+    public ResponseEntity<PurchaseResponseDto> createPurchase(
+            @RequestBody @Valid PurchaseRequestDto purchaseRequestDto) {
+        try {
+            PurchaseResponseDto purchaseDTO = purchaseService.createPurchase(purchaseRequestDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(purchaseDTO);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+    }
+
+    @GetMapping("/{purchaseId}")
+    public ResponseEntity<PurchaseResponseDto> getPurchaseById(@PathVariable Long purchaseId) {
+        try {
+            PurchaseResponseDto purchaseDTO = purchaseService.getPurchaseById(purchaseId);
+            return ResponseEntity.ok(purchaseDTO);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<PurchaseResponseDto>> getAllPurchases(@PathVariable Long userId) {
+        try {
+            List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser(userId);
+            return ResponseEntity.ok(purchases);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
+    @DeleteMapping("/{purchaseId}")
+    public ResponseEntity<Void> deletePurchase(@PathVariable Long purchaseId) {
+        try {
+            purchaseService.deletePurchase(purchaseId);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
@@ -50,10 +50,10 @@ public class PurchaseController {
         }
     }
 
-    @GetMapping("/user/{userId}")
-    public ResponseEntity<List<PurchaseResponseDto>> getAllPurchases(@PathVariable Long userId) {
+    @GetMapping("/all")
+    public ResponseEntity<List<PurchaseResponseDto>> getAllPurchases() {
         try {
-            List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser(userId);
+            List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser();
             return ResponseEntity.ok(purchases);
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
@@ -2,6 +2,7 @@ package br.db.ecotrack.ecotrack_api.controller;
 
 import java.util.List;
 
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -37,8 +38,8 @@ public class PurchaseController {
             return ResponseEntity.status(HttpStatus.CREATED).body(purchaseDTO);
         } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } 
-}
+        }
+    }
 
     @GetMapping("/{purchaseId}")
     public ResponseEntity<PurchaseResponseDto> getPurchaseById(@PathVariable Long purchaseId) {
@@ -52,14 +53,8 @@ public class PurchaseController {
 
     @GetMapping("/all")
     public ResponseEntity<List<PurchaseResponseDto>> getAllPurchases() {
-        try {
-            List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser();
-            return ResponseEntity.ok(purchases);
-        } catch (EntityNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        } catch (SecurityException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+        List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser();
+        return ResponseEntity.ok(purchases);
     }
 
     @DeleteMapping("/{purchaseId}")

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
 import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
 import br.db.ecotrack.ecotrack_api.service.PurchaseService;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,7 +17,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,17 +35,17 @@ public class PurchaseController {
         try {
             PurchaseResponseDto purchaseDTO = purchaseService.createPurchase(purchaseRequestDto);
             return ResponseEntity.status(HttpStatus.CREATED).body(purchaseDTO);
-        } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).build();
-        }
-    }
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } 
+}
 
     @GetMapping("/{purchaseId}")
     public ResponseEntity<PurchaseResponseDto> getPurchaseById(@PathVariable Long purchaseId) {
         try {
             PurchaseResponseDto purchaseDTO = purchaseService.getPurchaseById(purchaseId);
             return ResponseEntity.ok(purchaseDTO);
-        } catch (Exception e) {
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }
@@ -55,8 +55,10 @@ public class PurchaseController {
         try {
             List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser();
             return ResponseEntity.ok(purchases);
-        } catch (Exception e) {
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (SecurityException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
     }
 
@@ -65,7 +67,7 @@ public class PurchaseController {
         try {
             purchaseService.deletePurchase(purchaseId);
             return ResponseEntity.noContent().build();
-        } catch (Exception e) {
+        } catch (EntityNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/PurchaseController.java
@@ -1,17 +1,13 @@
 package br.db.ecotrack.ecotrack_api.controller;
 
 import java.util.List;
-
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
 import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
 import br.db.ecotrack.ecotrack_api.service.PurchaseService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
-
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,8 +27,7 @@ public class PurchaseController {
     }
 
     @PostMapping
-    public ResponseEntity<PurchaseResponseDto> createPurchase(
-            @RequestBody @Valid PurchaseRequestDto purchaseRequestDto) {
+    public ResponseEntity<?> createPurchase(@RequestBody @Valid PurchaseRequestDto purchaseRequestDto) {
         try {
             PurchaseResponseDto purchaseDTO = purchaseService.createPurchase(purchaseRequestDto);
             return ResponseEntity.status(HttpStatus.CREATED).body(purchaseDTO);
@@ -51,9 +46,9 @@ public class PurchaseController {
         }
     }
 
-    @GetMapping("/all")
+    @GetMapping
     public ResponseEntity<List<PurchaseResponseDto>> getAllPurchases() {
-        List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesByUser();
+        List<PurchaseResponseDto> purchases = purchaseService.getAllPurchasesForCurrentUser();
         return ResponseEntity.ok(purchases);
     }
 

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
@@ -1,14 +1,14 @@
 package br.db.ecotrack.ecotrack_api.controller.request;
 
 import java.time.LocalDate;
-
 import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.Positive;
 
 public record PurchaseRequestDto(
     @NotNull(message = "Quantidade é obrigatória") @Positive(message = "Quantidade deve ser positiva") Double quantity,
     @NotNull(message = "A unidade é obrigatória") MeasurementUnit measurementUnit,
-    @NotNull(message = "Data da compra é obrigatória") LocalDate purchaseDate,
+    @NotNull(message = "Data da compra é obrigatória") @PastOrPresent(message = "A data da compra não pode ser no futuro") LocalDate purchaseDate,
     @NotNull(message = "Id do Material é obrigatório") Long materialId) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
@@ -4,17 +4,11 @@ import java.time.LocalDate;
 
 import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record PurchaseRequestDto(
-    @NotNull(message = "Quantidade é obrigatória")
-    Double quantity,
-
-    @NotNull(message = "A unidade é obrigatória")
-    MeasurementUnit measurementUnit,
-
-    @NotNull(message = "Data da compra é obrigatória")
-    LocalDate purchaseDate,
-
-    @NotNull(message = "Id do Material é obrigatório")
-    Long materialId) {
+    @NotNull(message = "Quantidade é obrigatória") @Positive(message = "Quantidade deve ser positiva") Double quantity,
+    @NotNull(message = "A unidade é obrigatória") MeasurementUnit measurementUnit,
+    @NotNull(message = "Data da compra é obrigatória") LocalDate purchaseDate,
+    @NotNull(message = "Id do Material é obrigatório") Long materialId) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.Positive;
 
 public record PurchaseRequestDto(
     @NotNull(message = "Quantidade é obrigatória") @Positive(message = "Quantidade deve ser positiva") Double quantity,
-    @NotNull(message = "A unidade é obrigatória") MeasurementUnit measurementUnit,
+    @NotNull(message = "A unidade é obrigatória") MeasurementUnit unit,
     @NotNull(message = "Data da compra é obrigatória") @PastOrPresent(message = "A data da compra não pode ser no futuro") LocalDate purchaseDate,
     @NotNull(message = "Id do Material é obrigatório") Long materialId) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/request/PurchaseRequestDto.java
@@ -1,0 +1,20 @@
+package br.db.ecotrack.ecotrack_api.controller.request;
+
+import java.time.LocalDate;
+
+import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
+import jakarta.validation.constraints.NotNull;
+
+public record PurchaseRequestDto(
+    @NotNull(message = "Quantidade é obrigatória")
+    Double quantity,
+
+    @NotNull(message = "A unidade é obrigatória")
+    MeasurementUnit measurementUnit,
+
+    @NotNull(message = "Data da compra é obrigatória")
+    LocalDate purchaseDate,
+
+    @NotNull(message = "Id do Material é obrigatório")
+    Long materialId) {
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
@@ -2,12 +2,9 @@ package br.db.ecotrack.ecotrack_api.controller.response;
 
 import java.time.LocalDate;
 
-import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
-
 public record PurchaseResponseDto(
     Long purchaseId,
     Double quantity,
-    MeasurementUnit measurementUnit,
     LocalDate purchaseDate,
-    String materialType) { 
+    String materialType) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
@@ -6,7 +6,7 @@ import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
 public record PurchaseResponseDto(
     Long purchaseId,
     Double quantity,
-    MeasurementUnit measurementUnit,
+    MeasurementUnit unit,
     LocalDate purchaseDate,
     String materialType) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
@@ -1,10 +1,12 @@
 package br.db.ecotrack.ecotrack_api.controller.response;
 
 import java.time.LocalDate;
+import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
 
 public record PurchaseResponseDto(
     Long purchaseId,
     Double quantity,
+    MeasurementUnit measurementUnit,
     LocalDate purchaseDate,
     String materialType) {
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/controller/response/PurchaseResponseDto.java
@@ -1,0 +1,13 @@
+package br.db.ecotrack.ecotrack_api.controller.response;
+
+import java.time.LocalDate;
+
+import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
+
+public record PurchaseResponseDto(
+    Long purchaseId,
+    Double quantity,
+    MeasurementUnit measurementUnit,
+    LocalDate purchaseDate,
+    String materialType) { 
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/Purchase.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/domain/entity/Purchase.java
@@ -3,6 +3,9 @@ package br.db.ecotrack.ecotrack_api.domain.entity;
 import java.time.LocalDate;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import br.db.ecotrack.ecotrack_api.domain.enums.MeasurementUnit;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,6 +32,10 @@ public class Purchase {
 
   @Column(nullable = false)
   private Double quantity;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private MeasurementUnit unit;
 
   @Column(nullable = false)
   private LocalDate purchaseDate;

--- a/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
@@ -2,7 +2,6 @@ package br.db.ecotrack.ecotrack_api.mapper;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-
 import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
 import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
 import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;

--- a/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
@@ -10,8 +10,12 @@ import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
 @Mapper(componentModel = "spring")
 public interface PurchaseMapper {
 
+    
+    @Mapping(target = "materialType", source = "material.type")
     PurchaseResponseDto toDto(Purchase purchase);
 
+    @Mapping(target = "material", ignore = true)
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "purchaseId", ignore = true)
     Purchase toEntity(PurchaseRequestDto purchaseRequestDto);
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
@@ -10,8 +10,6 @@ import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
 @Mapper(componentModel = "spring")
 public interface PurchaseMapper {
 
-    
-    @Mapping(target = "materialType", source = "material.type")
     PurchaseResponseDto toDto(Purchase purchase);
 
     @Mapping(target = "material", ignore = true)

--- a/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
@@ -1,0 +1,17 @@
+package br.db.ecotrack.ecotrack_api.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
+import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
+import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
+
+@Mapper(componentModel = "spring")
+public interface PurchaseMapper {
+
+    PurchaseResponseDto toDto(Purchase purchase);
+
+    @Mapping(target = "purchaseId", ignore = true)
+    Purchase toEntity(PurchaseRequestDto purchaseRequestDto);
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/mapper/PurchaseMapper.java
@@ -10,6 +10,7 @@ import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
 @Mapper(componentModel = "spring")
 public interface PurchaseMapper {
 
+    @Mapping(target = "materialType", source = "material.type")
     PurchaseResponseDto toDto(Purchase purchase);
 
     @Mapping(target = "material", ignore = true)

--- a/src/main/java/br/db/ecotrack/ecotrack_api/repository/PurchaseRepository.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/repository/PurchaseRepository.java
@@ -1,14 +1,12 @@
 package br.db.ecotrack.ecotrack_api.repository;
 
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
 import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
+import br.db.ecotrack.ecotrack_api.domain.entity.User;
 
 @Repository
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
-
-    List<Purchase> findAllByUser_UserId(Long userId);
+    List<Purchase> findByUser(User user); 
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/repository/PurchaseRepository.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/repository/PurchaseRepository.java
@@ -1,0 +1,14 @@
+package br.db.ecotrack.ecotrack_api.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
+
+@Repository
+public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
+
+    List<Purchase> findAllByUser_UserId(Long userId);
+}

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/AuthService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/AuthService.java
@@ -73,7 +73,7 @@ public class AuthService {
   private LoginResponseDto buildLoginResponse(User user) {
     JwtClaimsSet jwt = JwtClaimsSet.builder()
         .issuer("ecotrack-api")
-        .subject(user.getName())
+        .subject(user.getUserId().toString())
         .issuedAt(Instant.now())
         .expiresAt(Instant.now().plusSeconds(expiresIn))
         .claim("email", user.getEmail())

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
@@ -6,6 +6,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 import br.db.ecotrack.ecotrack_api.controller.response.UserResponseDto;
+import br.db.ecotrack.ecotrack_api.domain.entity.User;
 import br.db.ecotrack.ecotrack_api.repository.UserRepository;
 
 @Service
@@ -15,6 +16,21 @@ public class CurrentUserService {
 
   public CurrentUserService(UserRepository userRepository) {
     this.userRepository = userRepository;
+  }
+
+  public Long getCurrentUserId() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    
+    if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) {
+        throw new SecurityException("Usuário não autenticado");
+    }
+    return Long.parseLong(jwt.getSubject());
+  }
+
+  public User getUserEntity() {
+    Long userId = getCurrentUserId();
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalStateException("Usuário não encontrado: " + userId));
   }
 
   public String getCurrentUserEmail() {

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
@@ -22,7 +22,7 @@ public class CurrentUserService {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     
     if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) {
-        throw new SecurityException("Usuário não autenticado");
+        throw new SecurityException("User not authenticated");
     }
     return Long.parseLong(jwt.getSubject());
   }
@@ -30,7 +30,7 @@ public class CurrentUserService {
   public User getUserEntity() {
     Long userId = getCurrentUserId();
     return userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalStateException("Usuário não encontrado: " + userId));
+        .orElseThrow(() -> new IllegalStateException("User not found: " + userId));
   }
 
   public String getCurrentUserEmail() {
@@ -42,7 +42,6 @@ public class CurrentUserService {
   public UserResponseDto get() {
     return userRepository.findByEmail(getCurrentUserEmail())
         .map(user -> new UserResponseDto(user.getUserId(), user.getName(), user.getEmail()))
-        .orElseThrow(() -> new IllegalStateException("Usuário não encontrado"));
+        .orElseThrow(() -> new IllegalStateException("User not found"));
   }
-
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/CurrentUserService.java
@@ -17,21 +17,6 @@ public class CurrentUserService {
     this.userRepository = userRepository;
   }
 
-  public Long getCurrentUserId() {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    
-    if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) {
-        throw new SecurityException("Usuário não autenticado");
-    }
-    return Long.parseLong(jwt.getSubject());
-  }
-
-  public User getUserEntity() {
-    Long userId = getCurrentUserId();
-    return userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalStateException("Usuário não encontrado: " + userId));
-  }
-
   public String getCurrentUserEmail() {
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
     Jwt jwt = (Jwt) authentication.getPrincipal();
@@ -53,4 +38,5 @@ public class CurrentUserService {
         .orElseThrow(() -> new IllegalStateException(
             "Usuário autenticado com o email '" + email + "' não foi encontrado no banco de dados."));
   }
+
 }

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
@@ -57,14 +57,10 @@ public class PurchaseService {
     }
 
     @Transactional(readOnly = true)
-    public List<PurchaseResponseDto> getAllPurchasesByUser(Long userId) {
+    public List<PurchaseResponseDto> getAllPurchasesByUser() {
         Long currentUserId = currentUserService.getCurrentUserId();
 
-        if (!currentUserId.equals(userId)) {
-            throw new SecurityException("Access denied for user: " + currentUserId);
-        }
-
-        return purchaseRepository.findAllByUser_UserId(userId)
+        return purchaseRepository.findAllByUser_UserId(currentUserId)
                 .stream()
                 .map(purchase -> purchaseMapper.toDto(purchase))
                 .toList();

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
@@ -14,7 +14,6 @@ import br.db.ecotrack.ecotrack_api.mapper.PurchaseMapper;
 import br.db.ecotrack.ecotrack_api.repository.MaterialRepository;
 import br.db.ecotrack.ecotrack_api.repository.PurchaseRepository;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.validation.Valid;
 
 @Service
 public class PurchaseService {
@@ -33,7 +32,7 @@ public class PurchaseService {
     }
 
     @Transactional
-    public PurchaseResponseDto createPurchase(@Valid PurchaseRequestDto purchaseRequestDto) {
+    public PurchaseResponseDto createPurchase(PurchaseRequestDto purchaseRequestDto) {
         User user = currentUserService.getUserEntity();
 
         Material material = materialRepository.findById(purchaseRequestDto.materialId())

--- a/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
+++ b/src/main/java/br/db/ecotrack/ecotrack_api/service/PurchaseService.java
@@ -1,0 +1,79 @@
+package br.db.ecotrack.ecotrack_api.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import br.db.ecotrack.ecotrack_api.controller.request.PurchaseRequestDto;
+import br.db.ecotrack.ecotrack_api.controller.response.PurchaseResponseDto;
+import br.db.ecotrack.ecotrack_api.domain.entity.Material;
+import br.db.ecotrack.ecotrack_api.domain.entity.Purchase;
+import br.db.ecotrack.ecotrack_api.domain.entity.User;
+import br.db.ecotrack.ecotrack_api.mapper.PurchaseMapper;
+import br.db.ecotrack.ecotrack_api.repository.MaterialRepository;
+import br.db.ecotrack.ecotrack_api.repository.PurchaseRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+
+@Service
+public class PurchaseService {
+
+    private final CurrentUserService currentUserService;
+    private final PurchaseRepository purchaseRepository;
+    private final MaterialRepository materialRepository;
+    private final PurchaseMapper purchaseMapper;
+
+    public PurchaseService(PurchaseRepository purchaseRepository, PurchaseMapper purchaseMapper,
+            CurrentUserService currentUserService, MaterialRepository materialRepository) {
+        this.purchaseRepository = purchaseRepository;
+        this.purchaseMapper = purchaseMapper;
+        this.currentUserService = currentUserService;
+        this.materialRepository = materialRepository;
+    }
+
+    @Transactional
+    public PurchaseResponseDto createPurchase(@Valid PurchaseRequestDto purchaseRequestDto) {
+        User user = currentUserService.getUserEntity();
+
+        Material material = materialRepository.findById(purchaseRequestDto.materialId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Material not found: " + purchaseRequestDto.materialId()));
+
+        Purchase purchase = purchaseMapper.toEntity(purchaseRequestDto);
+        purchase.setUser(user);
+        purchase.setMaterial(material);
+
+        Purchase purchaseSaved = purchaseRepository.save(purchase);
+
+        return purchaseMapper.toDto(purchaseSaved);
+    }
+
+    @Transactional(readOnly = true)
+    public PurchaseResponseDto getPurchaseById(Long purchaseId) {
+        return purchaseRepository.findById(purchaseId)
+                .map(purchase -> purchaseMapper.toDto(purchase))
+                .orElseThrow(() -> new EntityNotFoundException("Purchase not found: " + purchaseId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PurchaseResponseDto> getAllPurchasesByUser(Long userId) {
+        Long currentUserId = currentUserService.getCurrentUserId();
+
+        if (!currentUserId.equals(userId)) {
+            throw new SecurityException("Access denied for user: " + currentUserId);
+        }
+
+        return purchaseRepository.findAllByUser_UserId(userId)
+                .stream()
+                .map(purchase -> purchaseMapper.toDto(purchase))
+                .toList();
+    }
+
+    @Transactional
+    public void deletePurchase(Long purchaseId) {
+        Purchase purchase = purchaseRepository.findById(purchaseId)
+                .orElseThrow(() -> new EntityNotFoundException("Purchase not found: " + purchaseId));
+        purchaseRepository.deleteById(purchaseId);
+    }
+}


### PR DESCRIPTION
Este PR adiciona a funcionalidade completa de CRUD para o módulo de Purchases no backend, incluindo:

**Criação do PurchaseController com endpoints:**

- POST /api/purchases – criar nova compra

- GET /api/purchases/user/{id} – listar compras de um usuário especifico

- GET /api/purchases/{id} – buscar compra por ID

- DELETE /api/purchases/{id} – deletar compra por ID


Ajuste no PurchaseMapper para suportar a conversão entre entidades e DTOs.
Alterações no AuthService e CurrentUserService para facilitar a associação de compras ao usuário autenticado.

Após análise avaliar as seguintes sugestões:

- **Lembrar de refatorar o CurrentUserSevice  - getCurrentUserEmail** 
- **Fazer uma interface para CurrentUser e injetar no controller de compras e resíduos**
